### PR TITLE
Add moar things

### DIFF
--- a/dockhub.py
+++ b/dockhub.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import requests
 import click
+import json
 from os import getenv
 from sys import exit
 
@@ -40,14 +41,15 @@ def get_auth_token():
         die('For security, you must set your username as the variable DH_USERNAME in your ENV')
 
 
-def get_team(auth_header, dh_team):
-    docker_api_url = f'{dockerhub_url}/orgs/mozilla/groups/{dh_team}'
+def get_group_id(auth_header, dh_group):
+    # We need the group id to add the group to the repo later on
+    docker_api_url = f'{dockerhub_url}/orgs/mozilla/groups/{dh_group}'
     try:
-        team = requests.get(docker_api_url, headers=auth_header)
-        if team.status_code == 200:
-            return team.json()['id']
+        group = requests.get(docker_api_url, headers=auth_header)
+        if group.status_code == 200:
+            return group.json()['id']
         else:
-            die("Non-200 response form DockerHub. Verify your team name and try agin")
+            die("Non-200 response form DockerHub. Verify your group name and try agin")
     except requests.ConnectionError as e:
         die('Unable to connect to dockerhub:', e)
     except requests.HTTPError as e:
@@ -58,25 +60,60 @@ def get_team(auth_header, dh_team):
         die('Too many redirects encountered:', e)
 
 
-def add_user_to_team(auth_header, dh_user, dh_team, group_id):
-    docker_api_url = f'{dockerhub_url}/orgs/mozilla/groups/{dh_team}/members/'
-    add_user_headers = {**auth_header, **content_header}
+def dump_group_info(auth_header, dh_group):
+    group_url = f'{dockerhub_url}/orgs/mozilla/groups/{dh_group}'
+    group_members_url = f'{group_url}/members'
+    try:
+        group = requests.get(group_url, headers=auth_header)
+        if group.status_code == 200:
+            print(f'group information for {dh_group}')
+            print(json.dumps(group.json(), indent=2, sort_keys=True))
+        else:
+            die("Non-200 response form DockerHub. Verify your group name and try agin")
+    except requests.ConnectionError as e:
+        die('Unable to connect to dockerhub:', e)
+    except requests.HTTPError as e:
+        die('HTTPError:', e)
+    except requests.Timeout as e:
+        die('Timeout error:', e)
+    except requests.TooManyRedirects as e:
+        die('Too many redirects encountered:', e)
+    try:
+        members = requests.get(group_members_url, headers=auth_header)
+        if group.status_code == 200:
+            print(f'Membership information for {dh_group}')
+            print(json.dumps(members.json(), indent=2, sort_keys=True))
+        else:
+            die("Non-200 response form DockerHub. Verify your group name and try agin")
+    except requests.ConnectionError as e:
+        die('Unable to connect to dockerhub:', e)
+    except requests.HTTPError as e:
+        die('HTTPError:', e)
+    except requests.Timeout as e:
+        die('Timeout error:', e)
+    except requests.TooManyRedirects as e:
+        die('Too many redirects encountered:', e)
+
+
+def add_user_to_group(auth_header, dh_user, dh_group, group_id):
+    group_members_url = f'{dockerhub_url}/orgs/mozilla/groups/{dh_group}/members/'
+    additional_headers = {**auth_header, **content_header}
     add_user_json = {"member": dh_user}
     try:
-        add_user = requests.post(docker_api_url,
-                                 headers=add_user_headers,
+        add_user = requests.post(group_members_url,
+                                 headers=additional_headers,
                                  json=add_user_json)
         if add_user.status_code == 200:
             # Ensure the user has been added by pulling the list of members
-            verify = requests.get(docker_api_url, headers=auth_header)
-            if verify.status_code == 200:
+            members = requests.get(group_members_url, headers=auth_header)
+            if members.status_code == 200:
                 # https://stackoverflow.com/questions/8653516/python-list-of-dictionaries-search
-                if next((x for x in verify.json() if x['username'] == f'{dh_user}'), None):
-                    print(f'Added {dh_user} to {dh_team}')
+                if next((x for x in members.json() if x['username'] == f'{dh_user}'), None):
+                    print(f'Added {dh_user} to {dh_group}')
                 else:
-                    die(f'Unknown error adding {dh_user} to {dh_team}')
+                    die(f'Unknown error adding {dh_user} to {dh_group}')
             else:
-                die(f'Could not verify {dh_user} has been added to {dh_team}. Caveat emptor!')
+                die(f'Could not verify {dh_user} has been added to {dh_group}. Caveat emptor!')
         else:
             die('Non-200 response from DockerHub. Review all the things and try again')
     except requests.ConnectionError as e:
@@ -89,19 +126,66 @@ def add_user_to_team(auth_header, dh_user, dh_team, group_id):
         die('Too many redirects encountered:', e)
 
 
-def add_team_to_repo(auth_header, dh_team, dh_repo, group_id):
-    docker_api_url = f'{dockerhub_url}/repositories/mozilla/{dh_repo}/groups/'
-    add_team_headers = {**auth_header, **content_header}
-    add_team_json = {'group_id': group_id, 'permission': 'write'}
+def dump_user_info(auth_header, dh_user):
+    user_url = f'{dockerhub_url}/users/{dh_user}'
     try:
-        add_team = requests.post(docker_api_url,
-                                 headers=add_team_headers,
-                                 json=add_team_json)
-        if add_team.status_code == 200:
-            if add_team.json()[0]['group_id'] == group_id:
-                print(f'Granted {dh_team} write access to {dh_repo}')
+        user = requests.get(user_url, headers=auth_header)
+        if user.status_code == 200:
+            print(f'User information for {dh_user}')
+            print(json.dumps(user.json(), indent=2, sort_keys=True))
+        else:
+            die("Non-200 response form DockerHub. Verify the specified user name and try agin")
+    except requests.ConnectionError as e:
+        die('Unable to connect to dockerhub:', e)
+    except requests.HTTPError as e:
+        die('HTTPError:', e)
+    except requests.Timeout as e:
+        die('Timeout error:', e)
+    except requests.TooManyRedirects as e:
+        die('Too many redirects encountered:', e)
+
+
+def remove_user_from_group(auth_header, dh_user, dh_group):
+    group_members_url = f'{dockerhub_url}/orgs/mozilla/groups/{dh_group}/members'
+    user_group_members_url = f'{dockerhub_url}/orgs/mozilla/groups/{dh_group}/members/{dh_user}'
+    additional_headers = {**auth_header, **content_header}
+    try:
+        removed_user = requests.delete(user_group_members_url, headers=additional_headers)
+        if removed_user.status_code == 204:
+            members = requests.get(group_members_url, headers=auth_header)
+            if members.status_code == 200:
+                # https://stackoverflow.com/questions/8653516/python-list-of-dictionaries-search
+                if next((x for x in members.json() if x['username'] == f'{dh_user}'), None):
+                    die(f'Unknown error removing {dh_user} from {dh_group}')
+                else:
+                    print(f'Removed {dh_user} from {dh_group}')
             else:
-                die(f'Unknown error adding {dh_team} to {dh_repo}')
+                die(f'Could not verify {dh_user} has been removed from {dh_group}. Caveat emptor!')
+        else:
+            die("Non-200 response form DockerHub. I give up.")
+    except requests.ConnectionError as e:
+        die('Unable to connect to dockerhub:', e)
+    except requests.HTTPError as e:
+        die('HTTPError:', e)
+    except requests.Timeout as e:
+        die('Timeout error:', e)
+    except requests.TooManyRedirects as e:
+        die('Too many redirects encountered:', e)
+
+
+def add_group_to_repo(auth_header, dh_group, dh_repo, group_id):
+    docker_api_url = f'{dockerhub_url}/repositories/mozilla/{dh_repo}/groups/'
+    additional_headers = {**auth_header, **content_header}
+    add_group_json = {'group_id': group_id, 'permission': 'write'}
+    try:
+        add_group = requests.post(docker_api_url,
+                                  headers=additional_headers,
+                                  json=add_group_json)
+        if add_group.status_code == 200:
+            if add_group.json()[0]['group_id'] == group_id:
+                print(f'Granted {dh_group} write access to {dh_repo}')
+            else:
+                die(f'Unknown error adding {dh_group} to {dh_repo}')
         else:
             die('Non-200 response from DockerHub. Review all the things and try again')
     except requests.ConnectionError as e:
@@ -112,25 +196,76 @@ def add_team_to_repo(auth_header, dh_team, dh_repo, group_id):
         die('Timeout error:', e)
     except requests.TooManyRedirects as e:
         die('Too many redirects encountered:', e)
+
+
+def dump_repo_info(auth_header, dh_repo):
+    # We're only gonna dump permissions and basic stats for the repo
+    repo_url = f'{dockerhub_url}/repositories/mozilla/{dh_repo}'
+    repo_permissions_url = f'{repo_url}/groups/'
+    try:
+        repo = requests.get(repo_url, headers=auth_header)
+        repo_perms = requests.get(repo_permissions_url, headers=auth_header)
+        if repo.status_code == 200 and repo_perms.status_code == 200:
+            print(f'Repo information for {dh_repo}')
+            r = {**repo.json(), **repo_perms.json()}
+            print(json.dumps(r, indent=2, sort_keys=True))
+        else:
+            die("Non-200 response form DockerHub. Verify the specified repo name and try agin")
+    except requests.ConnectionError as e:
+        die('Unable to connect to dockerhub:', e)
+    except requests.HTTPError as e:
+        die('HTTPError:', e)
+    except requests.Timeout as e:
+        die('Timeout error:', e)
+    except requests.TooManyRedirects as e:
+        die('Too many redirects encountered:', e)
+
+
+def remove_group_from_repo(auth_header, dh_group):
+    pass
 
 
 @click.command()
-@click.option('-r', '--dh_repo', default=None, help='DockerHub repo you want to add the team to with r/w access', required=False)
-@click.option('-t', '--dh_team', default=None, help='DockerHub team you want to add a user to', required=True)
-@click.option('-u', '--dh_user', default=None, help='DockerHub user you want to add to the team (most likely, mzcs<something>)', required=True)
-def main(dh_repo, dh_team, dh_user):
+@click.option('-r', '--dh_repo', default=None, help='DockerHub repo you want to add the group to with r/w access', required=False)
+@click.option('-g', '--dh_group', default=None, help='DockerHub group you want to add a user to', required=False)
+@click.option('-u', '--dh_user', default=None, help='DockerHub user you want to add to the group (most likely, mzcs<something>)', required=False)
+@click.option('-a', '--action', default="list", type=click.Choice(['list', 'add', 'remove']), help='What action to take: add, list (default), or remove', required=False)
+@click.option('-f', '--force', "force", is_flag=True, help='Force the action of removing a group from a repo. Only group and repo can be set when using this option', required=False)
+def main(dh_repo, dh_group, dh_user, action, force):
     """
     For this script to work properly, You'll need to export your DockerHub Username and
     password (DH_USERNAME/DH_PASSWORD) in your ENV.
 
-    Be sure to have created both your Team and your repo prior to running this script!
+    Be sure to have created both your group and your repo prior to running this script!
+
+    Our SOP is to add users to groups, groups to repos. While you can add users directly
+    to repos, that's not the way we do things, so it's not covered here.
+
+    This is especially relevant to removals; We remove users from groups, not groups from
+    repos.
+
     """
     token = get_auth_token()
     auth_header = {'Authorization': f'JWT {token}'}
-    group_id = get_team(auth_header, dh_team)
-    add_user_to_team(auth_header, dh_user, dh_team, group_id)
-    if dh_repo is not None:
-        add_team_to_repo(auth_header, dh_team, dh_repo, group_id)
+    if action == "list":
+        if dh_group is not None:
+            dump_group_info(auth_header, dh_group)
+        if dh_user is not None:
+            dump_user_info(auth_header, dh_user)
+        if dh_repo is not None:
+            dump_repo_info(auth_header, dh_repo)
+        exit(0)
+    if action == "add" or action == "remove":
+        group_id = get_group_id(auth_header, dh_group)
+        if action == "add":
+            add_user_to_group(auth_header, dh_user, dh_group, group_id)
+            if dh_repo is not None:
+                add_group_to_repo(auth_header, dh_group, dh_repo, group_id)
+        else:
+            if action == "remove":
+                remove_user_from_group(auth_header, dh_user, dh_group)
+                if dh_user is None and dh_repo is not None and force is not None:
+                    remove_group_from_repo(dh_repo, dh_group)
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 click
+json


### PR DESCRIPTION
- s/team/group/ because docker changes their nomenclature as the tides
- add options for dumping information from user/group/repo
- try to handle the hash-table that my options have become
- add the remove user from group logic and function
- fixup: force; make it a flag, not an option
- fixup: remove_user_from_group function call; don't need group_id
- fixup: s/???_headers/additional_headers/; could also be called
  post_headers?